### PR TITLE
Add missing methods from Font class

### DIFF
--- a/src/Common/Font.cs
+++ b/src/Common/Font.cs
@@ -15,7 +15,7 @@ public sealed class Font : IDisposable, ICloneable
 	/// Initializes a new <see cref='Font'/> that uses the specified existing <see cref='Font'/>
 	/// and <see cref='FontStyle'/> enumeration.
 	/// </summary>
-	/// <param name="prototype">The existing <see cref='Font'/> from which to create the new <see cref='Font'/></param>
+	/// <param name="prototype">The existing <see cref='Font'/> from which to create the new <see cref='Font'/>.</param>
 	/// <param name="newStyle">
 	/// The <see cref='FontStyle'/> to apply to the new <see cref='Font'/>. Multiple
 	/// values of the <see cref='FontStyle'/> enumeration can be combined with the OR operator.
@@ -34,7 +34,7 @@ public sealed class Font : IDisposable, ICloneable
 	/// <param name="style">The <see cref='FontStyle'/> of the new font.</param>
 	/// <param name="unit">The <see cref='GraphicsUnit'/> of the new font.</param>
 	/// <param name="gdiCharSet">A <see cref='Byte'/> that specifies a GDI character set to use for this font.</param>
-	/// <param name="gdiVerticalFont">A <see cref='Boolean'/> value indicating whether the new <see cref='Font'/> is derived from a GDI vertical font..</param>
+	/// <param name="gdiVerticalFont">A <see cref='Boolean'/> value indicating whether the new <see cref='Font'/> is derived from a GDI vertical font.</param>
 	public Font(FontFamily family, float size = 12, FontStyle style = FontStyle.Regular, GraphicsUnit unit = GraphicsUnit.Point, byte gdiCharSet = (byte)FONT_CHARSET.DEFAULT_CHARSET, bool gdiVerticalFont = false)
 	{
 		FontFamily = family ?? throw new ArgumentException("missing family");
@@ -286,7 +286,7 @@ public sealed class Font : IDisposable, ICloneable
 	/// <summary>
 	/// Gets the em-size, in points, of this <see cref='Font'/>.
 	/// </summary>
-	/// <returns>The em-size, in points, of this <see cref='Font'/></returns>
+	/// <returns>The em-size, in points, of this <see cref='Font'/>.</returns>
 	[Browsable(false)]
 	public float SizeInPoints => Size * GetFactor(DPI, Unit, GraphicsUnit.Point);
 	


### PR DESCRIPTION
Includes the definition of the following methods in the `Font` class:
- `FromHdc`
- `FromHfont`
- `FromLogFont`
- `ToHfont`
- `ToLogFont`

All of these methods are currently dummies and raise a `NotSupportedException` exception.

With this PR, the `Font` class will be fully defined.