### PR TITLE
Add LOGFONT struct

### DIFF
--- a/src/Common/Font.cs
+++ b/src/Common/Font.cs
@@ -324,7 +324,7 @@ public sealed class Font : IDisposable, ICloneable
 
 	/// <summary>
 	/// Returns the line spacing, in the current unit of a specified Graphics, of this <see cref='Font'/>.
-    /// </summary>
+	/// </summary>
 	public float GetHeight(object graphics)
 		=> throw new NotImplementedException(); // TODO: will be replaced by GetHeight(graphics.PageUnit, graphics.DpiY) when Graphics class had been implemented
 
@@ -342,63 +342,63 @@ public sealed class Font : IDisposable, ICloneable
 		=> (Metrics.Descent - Metrics.Ascent + Metrics.Leading) * GetFactor(dpi, unit, GraphicsUnit.Pixel);
 
 	/// <summary>
-    /// Creates a <see cref="Font"/> from the specified handle to a device context (HDC).
-    /// </summary>
-    /// <returns>The newly created <see cref="Font"/>.</returns>
+	/// Creates a <see cref="Font"/> from the specified handle to a device context (HDC).
+	/// </summary>
+	/// <returns>The newly created <see cref="Font"/>.</returns>
 	public static Font FromHdc(IntPtr hdc)
 		=> throw new NotSupportedException("unsupported by skia.");
 
 	/// <summary>
-    /// Creates a <see cref='Font'/> from the specified Windows handle.
-    /// </summary>
+	/// Creates a <see cref='Font'/> from the specified Windows handle.
+	/// </summary>
 	/// <returns>The newly created <see cref="Font"/>.</returns>
-    public static Font FromHfont(IntPtr hfont)
+	public static Font FromHfont(IntPtr hfont)
 		=> throw new NotSupportedException("unsupported by skia.");
 
 	/// <inheritdoc cref="FromLogFont(object)"/>
-    public static Font FromLogFont(in Interop.LOGFONT logFont)
+	public static Font FromLogFont(in Interop.LOGFONT logFont)
 		=> FromLogFont(logFont, IntPtr.Zero);
 
 	/// <inheritdoc cref="FromLogFont(object, IntPtr)"/>
-    public static Font FromLogFont(in Interop.LOGFONT logFont, IntPtr hdc)
+	public static Font FromLogFont(in Interop.LOGFONT logFont, IntPtr hdc)
 		=> FromLogFont(logFont as object, hdc);
 
 	/// <summary>
-    /// Creates a <see cref="Font"/> from the given <see cref="Interop.LOGFONT"/> using the screen device context.
-    /// </summary>
-    /// <param name="logFont">A boxed <see cref="Interop.LOGFONT"/>.</param>
-    /// <returns>The newly created <see cref="Font"/>.</returns>
-    public static Font FromLogFont(object logFont)
+	/// Creates a <see cref="Font"/> from the given <see cref="Interop.LOGFONT"/> using the screen device context.
+	/// </summary>
+	/// <param name="logFont">A boxed <see cref="Interop.LOGFONT"/>.</param>
+	/// <returns>The newly created <see cref="Font"/>.</returns>
+	public static Font FromLogFont(object logFont)
 		=> FromLogFont(logFont, IntPtr.Zero);
 
 	/// <summary>
-    /// Creates a <see cref="Font"/> from the given <see cref="Interop.LOGFONT"/> using the given device context.
-    /// </summary>
-    /// <param name="logFont">A boxed <see cref="Interop.LOGFONT"/>.</param>
-    /// <param name="hdc">Handle to a device context (HDC).</param>
-    /// <returns>The newly created <see cref="Font"/>.</returns>
-    public static Font FromLogFont(object logFont, IntPtr hdc)
+	/// Creates a <see cref="Font"/> from the given <see cref="Interop.LOGFONT"/> using the given device context.
+	/// </summary>
+	/// <param name="logFont">A boxed <see cref="Interop.LOGFONT"/>.</param>
+	/// <param name="hdc">Handle to a device context (HDC).</param>
+	/// <returns>The newly created <see cref="Font"/>.</returns>
+	public static Font FromLogFont(object logFont, IntPtr hdc)
 		=> throw new NotSupportedException("unsupported by skia.");
 
 	/// <summary>
-    /// Returns a handle to this <see cref='Font'/>.
-    /// </summary>
-    public IntPtr ToHfont()
+	/// Returns a handle to this <see cref='Font'/>.
+	/// </summary>
+	public IntPtr ToHfont()
 		=> throw new NotSupportedException("unsupported by skia.");
 
 	/// <inheritdoc cref="ToLogFont(object)"/>
-    public void ToLogFont(out Interop.LOGFONT logFont)
+	public void ToLogFont(out Interop.LOGFONT logFont)
 		=> ToLogFont(out logFont, null);
 
 	/// <inheritdoc cref="ToLogFont(object, object)"/>
-    public void ToLogFont(out Interop.LOGFONT logFont, object graphics)
+	public void ToLogFont(out Interop.LOGFONT logFont, object graphics)
 		=> ToLogFont(logFont = new Interop.LOGFONT(), graphics);
 
 	/// <summary>
 	/// Creates a GDI logical font (<see cref="Interop.LOGFONT"/>) structure from this <see cref="Font"/>.
 	/// </summary>
 	/// <param name="logFont">An <see cref="Object"/> to represent the <see cref="Interop.LOGFONT"/> structure that this method creates.</param>
-    public void ToLogFont(object logFont)
+	public void ToLogFont(object logFont)
 		=> ToLogFont(logFont, null);
 
 	/// <summary>
@@ -468,8 +468,8 @@ public sealed class Font : IDisposable, ICloneable
 	private static float GetFactor(float dpi, GraphicsUnit sourceUnit, GraphicsUnit targetUnit)
 	{
 		float sourceFactor = GetPointFactor(sourceUnit, dpi);
-        float targetFactor = GetPointFactor(targetUnit, dpi);
-        return sourceFactor / targetFactor;
+		float targetFactor = GetPointFactor(targetUnit, dpi);
+		return sourceFactor / targetFactor;
 
 		static float GetPointFactor(GraphicsUnit unit, float dpi) => unit switch
 		{

--- a/src/Common/Interop/GDIDEFS.cs
+++ b/src/Common/Interop/GDIDEFS.cs
@@ -2,98 +2,98 @@ namespace GeneXus.Drawing.Interop;
 
 internal static class GDI_CHARSET
 {
-    public const byte ANSI_CHARSET = 0x00;
-    public const byte DEFAULT_CHARSET = 0x01;
-    public const byte SYMBOL_CHARSET = 0x02;
-    public const byte MAC_CHARSET = 0x4D;
-    public const byte SHIFTJIS_CHARSET = 0x8;
-    public const byte HANGUL_CHARSET = 0x81;
-    public const byte JOHAB_CHARSET = 0x82;
-    public const byte GB2312_CHARSET = 0x86;
-    public const byte CHINESEBIG5_CHARSET = 0x88;
-    public const byte GREEK_CHARSET = 0xA1;
-    public const byte TURKISH_CHARSET = 0xA2;
-    public const byte VIETNAMESE_CHARSET = 0xA3;
-    public const byte HEBREW_CHARSET = 0xB1;
-    public const byte ARABIC_CHARSET = 0xB2;
-    public const byte BALTIC_CHARSET = 0xBA;
-    public const byte RUSSIAN_CHARSET = 0xCC;
-    public const byte THAI_CHARSET = 0xDE;
-    public const byte EASTEUROPE_CHARSET = 0xEE;
-    public const byte OEM_CHARSET = 0xFF;
+	public const byte ANSI_CHARSET = 0x00;
+	public const byte DEFAULT_CHARSET = 0x01;
+	public const byte SYMBOL_CHARSET = 0x02;
+	public const byte MAC_CHARSET = 0x4D;
+	public const byte SHIFTJIS_CHARSET = 0x8;
+	public const byte HANGUL_CHARSET = 0x81;
+	public const byte JOHAB_CHARSET = 0x82;
+	public const byte GB2312_CHARSET = 0x86;
+	public const byte CHINESEBIG5_CHARSET = 0x88;
+	public const byte GREEK_CHARSET = 0xA1;
+	public const byte TURKISH_CHARSET = 0xA2;
+	public const byte VIETNAMESE_CHARSET = 0xA3;
+	public const byte HEBREW_CHARSET = 0xB1;
+	public const byte ARABIC_CHARSET = 0xB2;
+	public const byte BALTIC_CHARSET = 0xBA;
+	public const byte RUSSIAN_CHARSET = 0xCC;
+	public const byte THAI_CHARSET = 0xDE;
+	public const byte EASTEUROPE_CHARSET = 0xEE;
+	public const byte OEM_CHARSET = 0xFF;
 }
 
 internal static class GDI_CLIP_PRECISION
 {
-    public const byte CLIP_DEFAULT_PRECIS = 0x00;
-    public const byte CLIP_CHARACTER_PRECIS = 0x01;
-    public const byte CLIP_STROKE_PRECIS = 0x02;
-    public const byte CLIP_MASK = 0x0F;
-    public const byte CLIP_LH_ANGLES = 0x10;
-    public const byte CLIP_TT_ALWAYS = 0x20;
-    public const byte CLIP_DFA_DISABLE = 0x40;
-    public const byte CLIP_EMBEDDED = 0x80;
+	public const byte CLIP_DEFAULT_PRECIS = 0x00;
+	public const byte CLIP_CHARACTER_PRECIS = 0x01;
+	public const byte CLIP_STROKE_PRECIS = 0x02;
+	public const byte CLIP_MASK = 0x0F;
+	public const byte CLIP_LH_ANGLES = 0x10;
+	public const byte CLIP_TT_ALWAYS = 0x20;
+	public const byte CLIP_DFA_DISABLE = 0x40;
+	public const byte CLIP_EMBEDDED = 0x80;
 }
 
 internal static class GDI_FONT_FAMILY
 {
-    public const byte FF_DONTCARE = 0x00;     // Don't care or don't know.
-    public const byte FF_ROMAN = 0x10;        // Variable stroke width, serifed (Times Roman, Century Schoolbook, etc.).
-    public const byte FF_SWISS = 0x20;        // Variable stroke width, sans-serifed (Helvetica, Swiss, etc.).
-    public const byte FF_MODERN = 0x30;       // Constant stroke width, serifed or sans-serifed (Pica, Elite, Courier, etc.).
-    public const byte FF_SCRIPT = 0x40;       // Cursive, etc.
-    public const byte FF_DECORATIVE = 0x50;   // Old English, etc.
+	public const byte FF_DONTCARE = 0x00;	 // Don't care or don't know.
+	public const byte FF_ROMAN = 0x10;		// Variable stroke width, serifed (Times Roman, Century Schoolbook, etc.).
+	public const byte FF_SWISS = 0x20;		// Variable stroke width, sans-serifed (Helvetica, Swiss, etc.).
+	public const byte FF_MODERN = 0x30;	   // Constant stroke width, serifed or sans-serifed (Pica, Elite, Courier, etc.).
+	public const byte FF_SCRIPT = 0x40;	   // Cursive, etc.
+	public const byte FF_DECORATIVE = 0x50;   // Old English, etc.
 }
 
 internal static class GDI_OUT_PRECISION
 {
-    public const byte OUT_DEFAULT_PRECIS = 0x00;
-    public const byte OUT_STRING_PRECIS = 0x01;
-    public const byte OUT_CHARACTER_PRECIS = 0x02;
-    public const byte OUT_STROKE_PRECIS = 0x03;
-    public const byte OUT_TT_PRECIS = 0x04;
-    public const byte OUT_DEVICE_PRECIS = 0x05;
-    public const byte OUT_RASTER_PRECIS = 0x06;
-    public const byte OUT_TT_ONLY_PRECIS = 0x07;
-    public const byte OUT_OUTLINE_PRECIS = 0x08;
-    public const byte OUT_SCREEN_OUTLINE_PRECIS = 0x09;
-    public const byte OUT_PS_ONLY_PRECIS = 0x0A;
+	public const byte OUT_DEFAULT_PRECIS = 0x00;
+	public const byte OUT_STRING_PRECIS = 0x01;
+	public const byte OUT_CHARACTER_PRECIS = 0x02;
+	public const byte OUT_STROKE_PRECIS = 0x03;
+	public const byte OUT_TT_PRECIS = 0x04;
+	public const byte OUT_DEVICE_PRECIS = 0x05;
+	public const byte OUT_RASTER_PRECIS = 0x06;
+	public const byte OUT_TT_ONLY_PRECIS = 0x07;
+	public const byte OUT_OUTLINE_PRECIS = 0x08;
+	public const byte OUT_SCREEN_OUTLINE_PRECIS = 0x09;
+	public const byte OUT_PS_ONLY_PRECIS = 0x0A;
 }
 
 internal static class GDI_PITCH_FONT
 {
-    public const byte DEFAULT_PITCH = 0x00;
-    public const byte FIXED_PITCH = 0x01;
-    public const byte VARIABLE_PITCH = 0x02;
+	public const byte DEFAULT_PITCH = 0x00;
+	public const byte FIXED_PITCH = 0x01;
+	public const byte VARIABLE_PITCH = 0x02;
 }
 
 internal static class GDI_FONT_QUALITY
 {
-    public const byte DEFAULT_QUALITY = 0x00;
-    public const byte DRAFT_QUALITY = 0x01;
-    public const byte PROOF_QUALITY = 0x02;
-    public const byte NONANTIALIASED_QUALITY = 0x03;
-    public const byte ANTIALIASED_QUALITY = 0x04;
-    public const byte CLEARTYPE_QUALITY = 0x05;
-    public const byte CLEARTYPE_NATURAL_QUALITY = 0x06;
+	public const byte DEFAULT_QUALITY = 0x00;
+	public const byte DRAFT_QUALITY = 0x01;
+	public const byte PROOF_QUALITY = 0x02;
+	public const byte NONANTIALIASED_QUALITY = 0x03;
+	public const byte ANTIALIASED_QUALITY = 0x04;
+	public const byte CLEARTYPE_QUALITY = 0x05;
+	public const byte CLEARTYPE_NATURAL_QUALITY = 0x06;
 }
 
 public static class GDI_WEIGHT
 {
-    public const int FW_DONTCARE = 0;
-    public const int FW_THIN = 100;
-    public const int FW_EXTRALIGHT = 200;
-    public const int FW_LIGHT = 300;
-    public const int FW_NORMAL = 400;
-    public const int FW_MEDIUM = 500;
-    public const int FW_SEMIBOLD = 600;
-    public const int FW_BOLD = 700;
-    public const int FW_EXTRABOLD = 800;
-    public const int FW_HEAVY = 900;
+	public const int FW_DONTCARE = 0;
+	public const int FW_THIN = 100;
+	public const int FW_EXTRALIGHT = 200;
+	public const int FW_LIGHT = 300;
+	public const int FW_NORMAL = 400;
+	public const int FW_MEDIUM = 500;
+	public const int FW_SEMIBOLD = 600;
+	public const int FW_BOLD = 700;
+	public const int FW_EXTRABOLD = 800;
+	public const int FW_HEAVY = 900;
 
-    public const int FW_ULTRALIGHT = FW_EXTRALIGHT;
-    public const int FW_REGULAR = FW_NORMAL;
-    public const int FW_DEMIBOLD = FW_SEMIBOLD;
-    public const int FW_ULTRABOLD = FW_EXTRABOLD;
-    public const int FW_BLACK = FW_HEAVY;
+	public const int FW_ULTRALIGHT = FW_EXTRALIGHT;
+	public const int FW_REGULAR = FW_NORMAL;
+	public const int FW_DEMIBOLD = FW_SEMIBOLD;
+	public const int FW_ULTRABOLD = FW_EXTRABOLD;
+	public const int FW_BLACK = FW_HEAVY;
 }

--- a/src/Common/Interop/LOGFONT.cs
+++ b/src/Common/Interop/LOGFONT.cs
@@ -5,85 +5,85 @@ namespace GeneXus.Drawing.Interop;
 [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
 public struct LOGFONT
 {
-    private const int LF_FACESIZE = 32;
+	private const int LF_FACESIZE = 32;
 
-    /// <summary>
-    /// The height of the font's character cell or character.
-    /// </summary>
-    public int lfHeight;
+	/// <summary>
+	/// The height of the font's character cell or character.
+	/// </summary>
+	public int lfHeight;
 
-    /// <summary>
-    /// The average width of characters in the font.
-    /// </summary>
-    public int lfWidth;
+	/// <summary>
+	/// The average width of characters in the font.
+	/// </summary>
+	public int lfWidth;
 
-    /// <summary>
-    /// The angle, in tenths of degrees, between the escapement vector and the x-axis.
-    /// </summary>
-    public int lfEscapement;
+	/// <summary>
+	/// The angle, in tenths of degrees, between the escapement vector and the x-axis.
+	/// </summary>
+	public int lfEscapement;
 
-    /// <summary>
-    /// The angle, in tenths of degrees, between each character's base line and the x-axis.
-    /// </summary>
-    public int lfOrientation;
+	/// <summary>
+	/// The angle, in tenths of degrees, between each character's base line and the x-axis.
+	/// </summary>
+	public int lfOrientation;
 
-    /// <summary>
-    /// The weight of the font in the range 0 through 1000.
-    /// </summary>
-    public int lfWeight;
+	/// <summary>
+	/// The weight of the font in the range 0 through 1000.
+	/// </summary>
+	public int lfWeight;
 
-    /// <summary>
-    /// Specifies an italic font if set to 1.
-    /// </summary>
-    public byte lfItalic;
+	/// <summary>
+	/// Specifies an italic font if set to 1.
+	/// </summary>
+	public byte lfItalic;
 
-    /// <summary>
-    /// Specifies an underlined font if set to 1.
-    /// </summary>
-    public byte lfUnderline;
+	/// <summary>
+	/// Specifies an underlined font if set to 1.
+	/// </summary>
+	public byte lfUnderline;
 
-    /// <summary>
-    /// Specifies a strikeout font if set to 1.
-    /// </summary>
-    public byte lfStrikeOut;
+	/// <summary>
+	/// Specifies a strikeout font if set to 1.
+	/// </summary>
+	public byte lfStrikeOut;
 
-    /// <summary>
-    /// The character set used by the font.
-    /// </summary>
-    public byte lfCharSet;
+	/// <summary>
+	/// The character set used by the font.
+	/// </summary>
+	public byte lfCharSet;
 
-    /// <summary>
-    /// The output precision, which defines how closely the output must match the requested font's 
-    /// height, width, character orientation, escapement, and pitch.
-    /// </summary>
-    public byte lfOutPrecision;
+	/// <summary>
+	/// The output precision, which defines how closely the output must match the requested font's 
+	/// height, width, character orientation, escapement, and pitch.
+	/// </summary>
+	public byte lfOutPrecision;
 
-    /// <summary>
-    /// The clipping precision, which defines how to clip characters that are partially outside
-    /// the clipping region.
-    /// </summary>
-    public byte lfClipPrecision;
+	/// <summary>
+	/// The clipping precision, which defines how to clip characters that are partially outside
+	/// the clipping region.
+	/// </summary>
+	public byte lfClipPrecision;
 
-    /// <summary>
-    /// The output quality, which defines how carefully the font must match the attributes of
-    /// the requested font.
-    /// </summary>
-    public byte lfQuality;
+	/// <summary>
+	/// The output quality, which defines how carefully the font must match the attributes of
+	/// the requested font.
+	/// </summary>
+	public byte lfQuality;
 
-    /// <summary>
-    /// The pitch and family of the font.
-    /// </summary>
-    public byte lfPitchAndFamily;
+	/// <summary>
+	/// The pitch and family of the font.
+	/// </summary>
+	public byte lfPitchAndFamily;
 
-    /// <summary>
-    /// A string specifying the typeface name of the font.
-    /// </summary>
-    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = LF_FACESIZE)]
-    public string lfFaceName;
+	/// <summary>
+	/// A string specifying the typeface name of the font.
+	/// </summary>
+	[MarshalAs(UnmanagedType.ByValTStr, SizeConst = LF_FACESIZE)]
+	public string lfFaceName;
 
-    internal readonly string AsString()
-        => $"lfHeight={lfHeight}, lfWidth={lfWidth}, lfEscapement={lfEscapement}, lfOrientation={lfOrientation}, "
-         + $"lfWeight={lfWeight}, lfItalic={lfItalic}, lfUnderline={lfUnderline}, lfStrikeOut={lfStrikeOut}, "
-         + $"lfCharSet={lfCharSet}, lfOutPrecision={lfOutPrecision}, lfClipPrecision={lfClipPrecision}, "
-         + $"lfQuality={lfQuality}, lfPitchAndFamily={lfPitchAndFamily}, lfFaceName={lfFaceName}";
+	internal readonly string AsString()
+		=> $"lfHeight={lfHeight}, lfWidth={lfWidth}, lfEscapement={lfEscapement}, lfOrientation={lfOrientation}, "
+		 + $"lfWeight={lfWeight}, lfItalic={lfItalic}, lfUnderline={lfUnderline}, lfStrikeOut={lfStrikeOut}, "
+		 + $"lfCharSet={lfCharSet}, lfOutPrecision={lfOutPrecision}, lfClipPrecision={lfClipPrecision}, "
+		 + $"lfQuality={lfQuality}, lfPitchAndFamily={lfPitchAndFamily}, lfFaceName={lfFaceName}";
 }


### PR DESCRIPTION
I added the LOGFONT struct used by `ToLogFont` and `FromLogFont` methods. 

I also added a set of related constants defined by GDI (see [LOGFONTA structure)](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-logfonta). They are not used, that's why are defined as `internal`, except in those `Font` constructors that receive `gdiCharSet` parameter (so I removed the `FONT_CHARSET` private enum that were defined in the `Font` class and now it uses the `GDI_CHARSET` static class values).