### PR TITLE
fix: Publish to nuget.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,15 +92,13 @@ jobs:
       run: |
         if ( '${{ env.IS_PUBLISH_TO_NUGETORG }}' -eq 'true' ) {
           # NuGet feed already defined at NuGet.Config
-          $pushArgs=@('--source', 'nuget.org', '--api-key', '${{ secrets.NUGET_ORG_TOKEN }}')
+          $pushArgs=@('nuget.org', '${{ secrets.NUGET_ORG_TOKEN }}')
         } else {
           $feedName="NuGetFeed4Deploy"
-          $pushArgs=@('--source', $feedName, '--api-key', 'DUMMY-KEY')
+          $pushArgs=@($feedName, 'DUMMY-KEY')
           dotnet nuget add source ${{ vars.AZURE_NEXUS_PRERELEASES_FEED }} --name $feedName --username gxbuilder --password ${{ secrets.AZURE_ARTIFACTS_TOKEN }}
-        }$feedName
-        $args = $pushArgs -join " "
-        write-host [debug] Push arguments: dotnet push $args
+        }
         Get-ChildItem .\_packages\$Env:Configuration\*.nupkg -Recurse |
           ForEach-Object {
-            dotnet nuget push $_.FullName $args 
+            dotnet nuget push $_.FullName --source $pushArgs[0] --api-key $pushArgs[1] 
           }


### PR DESCRIPTION
Arguments are different when publishing to nuget.org and to Azure. Also, avoid an error using "dotnet add source" for nuget.org, it is already defined in the NuGet.Config file.